### PR TITLE
Project repr title

### DIFF
--- a/pygameweb/project/models.py
+++ b/pygameweb/project/models.py
@@ -32,6 +32,9 @@ class Project(Base):
     datetimeon = Column(DateTime)
     image = Column(String(80))
 
+    def __repr__(self):
+        return "<Project with title=%r>" % self.title
+
     @property
     def summary_html(self):
         return sanitize_html(self.summary)


### PR DESCRIPTION
The releases admin page currently shows the project a release belongs to like this:

```
<pygameweb.project.models.Project object at 0x7f4fedbe4630> 
```

I hope that this change will let me see some more useful info:

```
<Project with title="Game of Life">
```