### PR TITLE
Admin interface improvements

### DIFF
--- a/pygameweb/admin/views.py
+++ b/pygameweb/admin/views.py
@@ -29,6 +29,9 @@ class UserAdmin(ModelView):
     form_excluded_columns = ('password',)
     column_auto_select_related = True
 
+    # Allow search by name (username), email or title (real name)
+    column_searchable_list = ['name', 'email', 'title']
+
     def is_accessible(self):
         return current_user.has_role('admin')
 

--- a/pygameweb/admin/views.py
+++ b/pygameweb/admin/views.py
@@ -11,7 +11,7 @@ from pygameweb.user.models import User, Group
 from pygameweb.page.models import Page
 
 from pygameweb.news.models import News
-from pygameweb.project.models import Project, Release
+from pygameweb.project.models import Project, Release, Tags
 
 
 
@@ -67,6 +67,12 @@ class ProjectAdmin(ModelView):
 
     def is_accessible(self):
         return current_user.has_role('admin')
+
+    def on_model_delete(self, project):
+        # Delete associated tags and releases so we can delete the project.
+        p = project
+        self.session.query(Tags).filter(Tags.project_id == p.id).delete()
+        self.session.query(Release).filter(Release.project_id == p.id).delete()
 
 class ReleaseAdmin(ModelView):
     # Don't show the long text fields in the list, but allow a details view

--- a/pygameweb/admin/views.py
+++ b/pygameweb/admin/views.py
@@ -83,6 +83,13 @@ class ReleaseAdmin(ModelView):
         return current_user.has_role('admin')
 
 class PageAdmin(ModelView):
+    # Don't show the long text fields in the list, but allow a details view
+    can_view_details = True
+    column_exclude_list = ['content']
+
+    # Allow search by title and name
+    column_searchable_list = ['name', 'title']
+
     def is_accessible(self):
         return current_user.has_role('admin')
 

--- a/pygameweb/admin/views.py
+++ b/pygameweb/admin/views.py
@@ -47,14 +47,32 @@ class GroupAdmin(ModelView):
         return current_user.has_role('admin')
 
 class NewsAdmin(ModelView):
+    # Don't show the long text fields in the list, but allow a details view
+    can_view_details = True
+    column_exclude_list = ['description']
+
+    # Allow search by title
+    column_searchable_list = ['title']
+
     def is_accessible(self):
         return current_user.has_role('admin')
 
 class ProjectAdmin(ModelView):
+    # Don't show the long text fields in the list, but allow a details view
+    can_view_details = True
+    column_exclude_list = ['summary', 'description']
+
+    # Allow search by title
+    column_searchable_list = ['title']
+
     def is_accessible(self):
         return current_user.has_role('admin')
 
 class ReleaseAdmin(ModelView):
+    # Don't show the long text fields in the list, but allow a details view
+    can_view_details = True
+    column_exclude_list = ['description']
+
     def is_accessible(self):
         return current_user.has_role('admin')
 


### PR DESCRIPTION
@illume these changes are meant to help us fight spam more easily - if you could merge this and deploy the site, that would be useful.

- Hide the long text fields from the lists of news, projects, releases and pages - the text can still be seen in a 'details' view.
- Allow searching news, projects and pages by title.
- Fix deleting a project from the admin interface: delete any associated tags and releases, so that the project itself can be deleted.

I've tested these changes briefly with a locally running server (once I worked out how to do that). They're based on the flask_admin docs, specifically [this section](http://flask-admin.readthedocs.io/en/latest/introduction/#customizing-built-in-views) and [this page](http://flask-admin.readthedocs.io/en/latest/api/mod_contrib_sqla/).

