### PR TITLE
wiki, improved table of contents. Syntax help. Clear cache after edit.

### DIFF
--- a/pygameweb/templates/wiki/edit.html
+++ b/pygameweb/templates/wiki/edit.html
@@ -12,6 +12,8 @@
     {{ wtf.form_errors(form, hiddens="only") }}
 
     <a href="#" id="richtext">Enable rich text editor</a>
+    <a href="/wiki/syntax" class="pull-right" title="view how to format things" target="_blank">syntax formatting help</a>
+
     {{ wtf.form_field(form.content, rows=15) }}
     {{ wtf.form_field(form.changes) }}
 

--- a/pygameweb/templates/wiki/view.html
+++ b/pygameweb/templates/wiki/view.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
 
-{% block title %}{% cache 60*5, link, 'title' %}
+{% block title %}{% cache 60*5, 'wiki_title', link %}
     {% set wiki = wiki_for(link) %}
     {{ wiki.title }} - pygame wiki
 {% endcache %}{% endblock title %}
 
 {% block content %}
-  {% cache 60*5, link %}
+  {% cache 60*5, 'wiki_content', link %}
   {% set wiki = wiki_for(link) %}
   {% set content_rendered, toc_rendered = wiki.content_toc %}
   {% if toc_rendered %}

--- a/pygameweb/templates/wiki/view.html
+++ b/pygameweb/templates/wiki/view.html
@@ -8,20 +8,115 @@
 {% block content %}
   {% cache 60*5, link %}
   {% set wiki = wiki_for(link) %}
-  <h1>{{ wiki.title }} &mdash; <a href="/wiki">wiki</a></h1>
+  {% set content_rendered, toc_rendered = wiki.content_toc %}
+  {% if toc_rendered %}
+    <div class="row">
+      <div class="col-sm-3 wiki-toc-nav">
+        {{ toc_rendered | safe }}
+      </div>
+      <div class="col-sm-9">
+  {% endif %}
 
-  <nav>
-    <a class="btn btn-default" href="{{ url_for('wiki.edit', link=link) }}" role="button">Edit</a>
-    <a class="btn btn-default" href="{{ url_for('wiki.source', link=link) }}" role="button">Source</a>
-    <a class="btn btn-default" href="{{ url_for('wiki.history', link=link) }}" role="button">History</a>
-    {#- <a class="btn btn-default" href="#" role="button">Links</a> -#}
-    {#- <a class="btn btn-default" href="#" role="button">Wiki Map</a> -#}
-    <a class="btn btn-default" href="{{ url_for('wiki.recent') }}" role="button">Recent Changes</a>
-  </nav>
+        <h1>{{ wiki.title }} &mdash; <a href="/wiki">wiki</a></h1>
 
-  <div>
-  {{ wiki.content_rendered | safe }}
-  </div>
+        <nav>
+          <a class="btn btn-default" href="{{ url_for('wiki.edit', link=link) }}" role="button">Edit</a>
+          <a class="btn btn-default" href="{{ url_for('wiki.source', link=link) }}" role="button">Source</a>
+          <a class="btn btn-default" href="{{ url_for('wiki.history', link=link) }}" role="button">History</a>
+          {#- <a class="btn btn-default" href="#" role="button">Links</a> -#}
+          {#- <a class="btn btn-default" href="#" role="button">Wiki Map</a> -#}
+          <a class="btn btn-default" href="{{ url_for('wiki.recent') }}" role="button">Recent Changes</a>
+        </nav>
+
+        <div class="wiki-content">
+          {{ content_rendered | safe }}
+        </div>
+
+  {% if toc_rendered %}
+      </div>
+    </div>
+  {% endif %}
 
   {% endcache %}
+{% endblock %}
+
+
+{#
+  Use a nicer side bar table of contents navigation component.
+  https://afeld.github.io/bootstrap-toc/
+#}
+
+
+
+{% block body_attribs %}{{ super() }}{% endblock body_attribs %}
+
+{%- block styles %}
+  {{ super() }}
+  <link rel="stylesheet" href="https://cdn.rawgit.com/afeld/bootstrap-toc/v0.4.1/dist/bootstrap-toc.min.css">
+  <style>
+
+
+    .wiki-toc-nav .nav {
+      max-width: 170px;
+    }
+    @media(max-width:768px){
+      .wiki-toc-nav .nav {
+        max-width: inherit;
+      }
+    }
+    @media(min-width:1200px){
+      .wiki-toc-nav .nav {
+        max-width: 250px;
+      }
+    }
+    .wiki-toc-nav .nav>li>a{
+      display:block;padding:4px 20px;font-size:13px;font-weight:500;color:#767676
+    }
+    .wiki-toc-nav .nav>li>a:focus,.wiki-toc-nav .nav>li>a:hover{
+      padding-left:19px;color:#563d7c;text-decoration:none;background-color:transparent;border-left:1px solid #563d7c
+    }
+    .wiki-toc-nav .nav>.active:focus>a,.wiki-toc-nav .nav>.active:hover>a,.wiki-toc-nav .nav>.active>a{
+      padding-left:18px;font-weight:700;color:#563d7c;background-color:transparent;border-left:2px solid #563d7c
+    }
+    .wiki-toc-nav .nav .nav{
+      display:none;padding-bottom:10px
+    }
+    .wiki-toc-nav .nav .nav>li>a{
+      padding-top:1px;padding-bottom:1px;padding-left:30px;font-size:12px;font-weight:400
+    }
+    .wiki-toc-nav .nav .nav>li>a:focus,.wiki-toc-nav .nav .nav>li>a:hover{
+      padding-left:29px
+    }
+    .wiki-toc-nav .nav .nav>.active:focus>a,.wiki-toc-nav .nav .nav>.active:hover>a,.wiki-toc-nav .nav .nav>.active>a{
+      padding-left:28px;font-weight:500
+    }
+    .wiki-toc-nav .nav>.active>ul{
+      display:block
+    }
+
+
+  </style>
+{% endblock %}
+{%- block scripts %}
+  {{ super() }}
+  <script>
+    $(function() {
+      var $toc = $('#toc'),
+        tooThin = $(window).width() < 769,
+        limit = $toc.offset().top,
+        shouldAffix = function () {
+          var scrollTop = $(window).scrollTop();
+          if (!tooThin && scrollTop >= limit) {
+            $toc.addClass('affix');
+          } else {
+            $toc.removeClass('affix');
+          }
+        };
+      $(window).scroll(function() { shouldAffix(); });
+      $(window).resize(function() {
+        tooThin = $(window).width() < 769;
+        shouldAffix();
+      });
+    });
+  </script>
 {% endblock %}

--- a/pygameweb/templates/wiki/view.html
+++ b/pygameweb/templates/wiki/view.html
@@ -100,23 +100,34 @@
 {%- block scripts %}
   {{ super() }}
   <script>
+/*
+ * jQuery throttle / debounce - v1.1 - 3/7/2010
+ * http://benalman.com/projects/jquery-throttle-debounce-plugin/
+ *
+ * Copyright (c) 2010 "Cowboy" Ben Alman
+ * Dual licensed under the MIT and GPL licenses.
+ * http://benalman.com/about/license/
+ */
+(function(b,c){var $=b.jQuery||b.Cowboy||(b.Cowboy={}),a;$.throttle=a=function(e,f,j,i){var h,d=0;if(typeof f!=="boolean"){i=j;j=f;f=c}function g(){var o=this,m=+new Date()-d,n=arguments;function l(){d=+new Date();j.apply(o,n)}function k(){h=c}if(i&&!h){l()}h&&clearTimeout(h);if(i===c&&m>e){l()}else{if(f!==true){h=setTimeout(i?k:l,i===c?e-m:e)}}}if($.guid){g.guid=j.guid=j.guid||$.guid++}return g};$.debounce=function(d,e,f){return f===c?a(d,e,false):a(d,f,e!==false)}})(this);
+
     $(function() {
       var $toc = $('#toc'),
         tooThin = $(window).width() < 769,
         limit = $toc.offset().top,
+        $window = $(window),
         shouldAffix = function () {
-          var scrollTop = $(window).scrollTop();
+          var scrollTop = $window.scrollTop();
           if (!tooThin && scrollTop >= limit) {
             $toc.addClass('affix');
           } else {
             $toc.removeClass('affix');
           }
         };
-      $(window).scroll(function() { shouldAffix(); });
-      $(window).resize(function() {
-        tooThin = $(window).width() < 769;
+      $(window).scroll($.throttle(150, shouldAffix));
+      $(window).resize($.throttle(150, function() {
+        tooThin = $window.width() < 769;
         shouldAffix();
-      });
+      }));
     });
   </script>
 {% endblock %}

--- a/pygameweb/wiki/models.py
+++ b/pygameweb/wiki/models.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm.session import make_transient
 from sqlalchemy.orm import relationship
 
 from pygameweb.models import Base
-from pygameweb.wiki.wiki import render
+from pygameweb.wiki.wiki import render, render_pq
 from pygameweb.user.models import User
 from pygameweb.sanitize import sanitize_html
 
@@ -83,6 +83,22 @@ class Wiki(Base):
             return Wiki.content_for_link(session, link)
 
         return sanitize_html(render(self.content, for_link))
+
+    @property
+    def content_toc(self):
+        """The wiki content is rendered for display.
+        """
+        session = inspect(self).session
+
+        def for_link(link):
+            return Wiki.content_for_link(session, link)
+
+        if not self.content:
+            return '', ''
+        content, toc = render_pq(self.content, for_link, toc_separate=True)
+        return (sanitize_html(content.outerHtml() if content is not None else ''),
+                sanitize_html(toc.outerHtml() if toc is not None else ''))
+
 
     @property
     def content_sanitized(self):

--- a/tests/unit/pygameweb/wiki/test_wiki.py
+++ b/tests/unit/pygameweb/wiki/test_wiki.py
@@ -56,7 +56,6 @@ def test_wiki_code():
     should_be = ('<div class="highlight"><pre><span></span>'
                  '<span class="n">my_code</span><span class="p">()</span>'
                  '\n</pre></div>\n')
-
     assert code.endswith(should_be), 'because code should be annotated'
     assert '<style>' in code, 'because there should be css'
 
@@ -78,8 +77,13 @@ def test_wiki_section():
 
     <h2>Another section, another day</h2>
     Pleasure in other peoples leasure.
+
+    <h3>Three levels deep</h3>
+    On top of Prenzlauer Berg Berg.
+
+    <h2>And finally the last one</h2>
+
     """
     res = _wiki_section(content).outerHtml()
     assert '<h1 id="Hello there matey">' in res, 'because headers should have an id'
     assert '<h2 id="Another section, another day">' in res
-


### PR DESCRIPTION
For https://github.com/pygame/pygameweb/issues/20

Does not take up so much horizontal space on wide screens.
Is sticky on wide screens, it shows on the left as you scroll.
Does not show every single header in the TOC.
Has nested nav headers, but they are not shown currently.
The ordering was incorrect before as well.
If there are no headers, the TOC is hidden.

For https://github.com/pygame/pygameweb/issues/22, link to syntax formatting help on wiki edit page.

For https://github.com/pygame/pygameweb/issues/19, clear cache on edit.