### PR TITLE
Wiki nicer pre code handling.

### DIFF
--- a/pygameweb/wiki/wiki.py
+++ b/pygameweb/wiki/wiki.py
@@ -91,11 +91,9 @@ def _wiki_code_callback(matchobj):
     content = re.sub(r'^\s*', '', content, re.S)
     content = re.sub(r'\s*$', '', content, re.S)
     # code_class = m[0]
-    formatter = HtmlFormatter()
-    styles = formatter.get_style_defs('.highlight')
+    formatter = HtmlFormatter(noclasses=True)
     code = highlight(content, PythonLexer(), formatter)
-
-    return f'<style>{styles}</style>{code}'
+    return code
 
 
 def _wiki_link(content):

--- a/pygameweb/wiki/wiki.py
+++ b/pygameweb/wiki/wiki.py
@@ -95,6 +95,20 @@ def _wiki_code_callback(matchobj):
     code = highlight(content, PythonLexer(), formatter)
     return code
 
+def _wiki_pre_code_clean(pq_content):
+    """ remove the double pre when <pre><code></code></pre>.
+
+    For our tinymce rich text editor, we need to wrap code
+    tags inside of pre tags. However, rendering them looks
+    of silly because there is a pre wrapped in a pre.
+    """
+    if len(pq_content) == 1 and pq_content[0].tag == 'pre':
+        if len(pq_content.find('div.highlight')):
+            return pq(pq_content.find('div.highlight').outerHtml())
+
+    for div in pq_content.find('pre div.highlight'):
+        pq(div).parent().replace_with(pq(div))
+    return pq_content
 
 def _wiki_link(content):
     """
@@ -193,7 +207,6 @@ def _wiki_section(content):
         pq_content.prepend(toc)
     return pq_content
 
-
 def render_pq(content, for_link_cb=None, toc_separate=False):
     """ render the content, which is wiki markup.
 
@@ -211,6 +224,7 @@ def render_pq(content, for_link_cb=None, toc_separate=False):
     content = _wiki_link(content)
 
     pq_content = pq(content)
+    pq_content = _wiki_pre_code_clean(pq_content)
 
     for anchor in pq_content.find('a'):
         pq(anchor).attr('rel', 'nofollow')

--- a/tests/unit/pygameweb/wiki/test_wiki.py
+++ b/tests/unit/pygameweb/wiki/test_wiki.py
@@ -65,6 +65,26 @@ def test_wiki_code():
     assert should_be in code, 'because code should be annotated'
     assert '<html' not in code
 
+
+def test_wiki_code_pre():
+    """For our tinymce rich text editor, we need to wrap code
+       tags inside of pre tags. However, rendering them looks
+       kind of silly.
+    """
+    from pygameweb.wiki.wiki import _wiki_pre_code_clean, _wiki_code
+    from pyquery import PyQuery as pq
+    code = _wiki_code('<div><pre><code class="python">def my_code(x): return x + 1</code></pre></div>')
+    pq_content = pq(code)
+    pq_content = _wiki_pre_code_clean(pq_content)
+    assert pq_content.outerHtml().startswith('<div><div class="highlight"')
+
+    code = _wiki_code('<pre><code class="python">def my_code(x): return x + 1</code></pre>')
+    pq_content = pq(code)
+    pq_content = _wiki_pre_code_clean(pq_content)
+    assert pq_content.outerHtml().startswith('<div class="highlight"')
+
+
+
 def test_wiki_link():
     """turns the markup using [] into a html anchor tag.
     """

--- a/tests/unit/pygameweb/wiki/test_wiki.py
+++ b/tests/unit/pygameweb/wiki/test_wiki.py
@@ -52,13 +52,18 @@ def test_wiki_href():
 
 def test_wiki_code():
     from pygameweb.wiki.wiki import _wiki_code
-    code = _wiki_code('<code class="python">my_code()</code>')
-    should_be = ('<div class="highlight"><pre><span></span>'
-                 '<span class="n">my_code</span><span class="p">()</span>'
-                 '\n</pre></div>\n')
-    assert code.endswith(should_be), 'because code should be annotated'
-    assert '<style>' in code, 'because there should be css'
+    code = _wiki_code('<code class="python">def my_code(x): return x + 1</code>')
 
+    should_be = (
+        '<pre style="line-height: 125%"><span></span>'
+        '<span style="color: #008000; font-weight: bold">def</span> '
+        '<span style="color: #0000FF">my_code</span>(x): '
+        '<span style="color: #008000; font-weight: bold">return</span> '
+        'x <span style="color: #666666">+</span> '
+        '<span style="color: #666666">1</span>\n</pre>'
+    )
+    assert should_be in code, 'because code should be annotated'
+    assert '<html' not in code
 
 def test_wiki_link():
     """turns the markup using [] into a html anchor tag.


### PR DESCRIPTION
- can copy/paste code blocks with color. Syntax highlighting is inline css, not classes.
- nicer rendering when dealing with tinymce oddity of needing to wrap a code block in a pre.