### PR TITLE
Allow GIFs please. :)

### DIFF
--- a/pygameweb/app.py
+++ b/pygameweb/app.py
@@ -18,6 +18,7 @@ def create_app(object_name='pygameweb.config.Config',
 
     from pygameweb import db
     app = Flask(__name__)
+    app.config['MAX_CONTENT_LENGTH'] = 3 * 1024 * 1024 # 3MB file upload cap
     app.config.from_object(object_name)
     Bootstrap(app)
 

--- a/pygameweb/project/forms.py
+++ b/pygameweb/project/forms.py
@@ -16,7 +16,7 @@ class ProjectForm(FlaskForm):
 
     image = FileField('image', validators=[
         # FileRequired(),
-        FileAllowed(['jpg', 'png'], 'Images only!')
+        FileAllowed(['jpg', 'png', 'gif'], 'Images and GIFs only! 3MB upload cap!')
     ])
 
 


### PR DESCRIPTION
I don't know if I did this right, but I looked through the flask docs and made a couple changes that _should_ allow gif uploads, but make them reasonable for the server to store (3MB cap). 

The fact that the projects can't really show what they are very well has bothered me for a while. I'd love to be able to upload short gifs to show what the projects are a little bit better.

I think that if there were some gifs playing on the "Recent Releases" section of the home page, people would see what pygame is capable of. This should help reduce the stigma that pygame is only for beginners and isn't capable of much.