### PR TITLE
Only show python examples when doing code search.

### DIFF
--- a/pygameweb/comment/static/jquery.plugin.docscomments.js
+++ b/pygameweb/comment/static/jquery.plugin.docscomments.js
@@ -119,9 +119,12 @@ $(document).ready(function () {
 
 
     var searchButtonHtml = [
-        '<form action="https://github.com/search" method="get" class="addcomment"><input type="hidden" value="',
-        '" name="q"><input type="hidden" name="type" value="Code"><input type="submit" value="Search examples for ',
-        '"></form>'
+        '<form action="https://github.com/search" method="get" class="addcomment">',
+        '<input type="hidden" value="" name="q">',
+        '<input type="hidden" name="type" value="Code">',
+        '<input type="hidden" name="l" value="Python" />',
+        '<input type="submit" value="Search examples for">',
+        '</form>'
     ];
 
     // Add "search internet for source code" buttons.


### PR DESCRIPTION
For https://github.com/pygame/pygame/issues/520

Before useless .h files, .html files would often show in results. Most people would be looking for python examples.