### PR TITLE
Fix jinja tag error in screenshots.html

### DIFF
--- a/pygameweb/templates/page/screenshots.html
+++ b/pygameweb/templates/page/screenshots.html
@@ -2,12 +2,12 @@
 
 {% block content %}
 
-    <h1>Page</h1>
+<h1>Page</h1>
 
-    {page.title}
-    {page.content}
-    {page.keywords}
-    {page.summary}
+	{{page.title}}
+	{{page.content}}
+	{{page.keywords}}
+	{{page.summary}}
 
 
 {% endblock %}


### PR DESCRIPTION
The screenshots page was incorrectly displaying the content jinja tags instead of rendering them.

I found this issue referenced in #26. All I did was add the missing pairs of brackets. :)

![image](https://user-images.githubusercontent.com/16241612/84492426-cb70f800-acc3-11ea-8c30-11e74938d948.png)

