### PR TITLE
Add a test for new projects without image

### DIFF
--- a/tests/functional/pygameweb/project/test_project_views.py
+++ b/tests/functional/pygameweb/project/test_project_views.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 import mock
 
@@ -307,7 +309,7 @@ def test_new_project_page(project_client, user):
         assert (label in resp.data), f'label {label} not present in page.'
 
 
-def test_add_new_project(project_client, session, user):
+def test_add_new_project(config, project_client, session, user):
     """ adds a new project for the user.
     """
     from io import BytesIO
@@ -340,8 +342,8 @@ def test_add_new_project(project_client, session, user):
                    .query(Project)
                    .filter(Project.title == 'title')
                    .first())
-        assert (save_image.call_args[0][1] ==
-                f'frontend/www/shots/{project.id}.png')
+        assert (str(Path(f'{config.WWW}/shots/{project.id}.png')) ==
+                save_image.call_args[0][1])
         resp = project_client.get(f'/project/{project.id}/')
         assert project.description.encode('utf8') in resp.data
 
@@ -370,8 +372,8 @@ def test_add_new_project(project_client, session, user):
                    .query(Project)
                    .filter(Project.title == 'titlechanged')
                    .first())
-        assert (save_image.call_args[0][1] ==
-                f'frontend/www/shots/{project.id}.png')
+        assert (str(Path(f'{config.WWW}/shots/{project.id}.png')) ==
+                save_image.call_args[0][1])
 
     data = dict(title='titlechangedagain',
                 tags='tag1, tag2, tag3', summary='summary',


### PR DESCRIPTION
It's a copy of the `new project test`, but without the png stuff.

Also refactored it a bit into `test_new_project_page` to test the html response.

