### PR TITLE
Add imagemagick to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,10 +34,11 @@ Set up the required packages::
     pip install -e .
 
 
-For now yuicompressor is needed for css compression::
+For now yuicompressor is needed for css compression, and
+imagamagick and optipng are needed for creating and optimizing image thumbnails::
 
-    brew install yuicompressor node optipng
-    apt-get install yui-compressor nodejs optipng
+    brew install yuicompressor node optipng imagemagick
+    apt-get install yui-compressor nodejs optipng imagemagick
 
 
 Environment setup


### PR DESCRIPTION
Imagemagick is used to create image thumbnails,
but it is not listed in the related section in the Quickstart.